### PR TITLE
Update example datasets

### DIFF
--- a/examples/00_user_setup/install_client.sh
+++ b/examples/00_user_setup/install_client.sh
@@ -1,4 +1,4 @@
-VERSION="2.0.0"
+VERSION="2.0.1"
 
 ENVNAME=fractal-client-$VERSION
 conda deactivate

--- a/examples/01_cardio_tiny_dataset/Parameters/args_cellpose_segmentation.json
+++ b/examples/01_cardio_tiny_dataset/Parameters/args_cellpose_segmentation.json
@@ -4,6 +4,7 @@
         "wavelength_id": "A01_C01"
     },
     "output_label_name": "nuclei", 
+    "output_ROI_table": "nuclei_ROI_table",
     "input_ROI_table": "well_ROI_table",
     "model_type": "nuclei",
     "diameter_level0": 60

--- a/examples/01_cardio_tiny_dataset/run_example.sh
+++ b/examples/01_cardio_tiny_dataset/run_example.sh
@@ -56,7 +56,7 @@ sed "s|__CURRENT_DIRECTORY__|$CURRENT_DIRECTORY|g" Parameters/RAW_args_measureme
 
 # Add tasks to workflow
 fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Convert Cellvoyager to OME-Zarr" --args-non-parallel Parameters/args_cellvoyager_to_ome_zarr_init.json --meta-non-parallel Parameters/example_meta.json
-fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Maximum Intensity Projection HCS Plate" --args-non-parallel Parameters/copy_ome_zarr.json
+fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Project Image (HCS Plate)" --args-non-parallel Parameters/copy_ome_zarr.json
 fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Cellpose Segmentation" --args-parallel Parameters/args_cellpose_segmentation.json
 fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Napari Workflows Wrapper" --args-parallel Parameters/args_measurement.json --meta-parallel Parameters/example_meta.json
 

--- a/examples/01_cardio_tiny_dataset/run_example_with_partial_execution.sh
+++ b/examples/01_cardio_tiny_dataset/run_example_with_partial_execution.sh
@@ -55,7 +55,7 @@ sed "s|__CURRENT_DIRECTORY__|$CURRENT_DIRECTORY|g" Parameters/RAW_args_measureme
 
 # Add tasks to workflow
 fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Convert Cellvoyager to OME-Zarr" --args-non-parallel Parameters/args_cellvoyager_to_ome_zarr_init.json --meta-non-parallel Parameters/example_meta.json
-fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Maximum Intensity Projection HCS Plate" --args-non-parallel Parameters/copy_ome_zarr.json
+fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Project Image (HCS Plate)" --args-non-parallel Parameters/copy_ome_zarr.json
 fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Cellpose Segmentation" --args-parallel Parameters/args_cellpose_segmentation.json
 fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Napari Workflows Wrapper" --args-parallel Parameters/args_measurement.json --meta-parallel Parameters/example_meta.json
 

--- a/examples/02_cardio_small/Parameters/RAW_args_cellvoyager_to_ome_zarr_init_subset.json
+++ b/examples/02_cardio_small/Parameters/RAW_args_cellvoyager_to_ome_zarr_init_subset.json
@@ -29,6 +29,6 @@
     "coarsening_xy": 2,
     "num_levels": 5,
     "image_extension": "png",
-    "image_glob_patterns": ["*F001*Z0[4,5]*"],
+    "include_glob_patterns": ["*F001*Z0[4,5]*"],
     "overwrite": true
 }

--- a/examples/02_cardio_small/Parameters/args_cellpose_segmentation.json
+++ b/examples/02_cardio_small/Parameters/args_cellpose_segmentation.json
@@ -4,6 +4,7 @@
         "wavelength_id": "A01_C01"
     },
     "output_label_name": "nuclei", 
+    "output_ROI_table": "nuclei_ROI_table",
     "input_ROI_table": "well_ROI_table",
     "model_type": "nuclei",
     "diameter_level0": 60

--- a/examples/02_cardio_small/Parameters/args_cellpose_segmentation_3D.json
+++ b/examples/02_cardio_small/Parameters/args_cellpose_segmentation_3D.json
@@ -4,6 +4,7 @@
     },
     "level": 2,
     "output_label_name": "nuclei",
+    "output_ROI_table": "nuclei_ROI_table",
     "input_ROI_table": "FOV_ROI_table",
     "model_type": "nuclei",
     "diameter_level0": 60

--- a/examples/02_cardio_small/run_example.sh
+++ b/examples/02_cardio_small/run_example.sh
@@ -72,7 +72,7 @@ fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Cellpose S
 fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Napari Workflows Wrapper" --args-parallel Parameters/args_measurements_3D.json
 
 # Maximum intensity projection
-fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Maximum Intensity Projection HCS Plate" --args-non-parallel Parameters/args_mip.json
+fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Project Image (HCS Plate)" --args-non-parallel Parameters/args_mip.json
 
 # 2D Segmentation
 fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Cellpose Segmentation" --args-parallel Parameters/args_cellpose_segmentation.json --meta-parallel Parameters/meta_cellpose.json

--- a/examples/02_cardio_small/run_example_on_image_subset.sh
+++ b/examples/02_cardio_small/run_example_on_image_subset.sh
@@ -72,7 +72,7 @@ fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Cellpose S
 fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Napari Workflows Wrapper" --args-parallel Parameters/args_measurements_3D.json
 
 # Maximum intensity projection
-fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Maximum Intensity Projection HCS Plate" --args-non-parallel Parameters/args_mip.json
+fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Project Image (HCS Plate)" --args-non-parallel Parameters/args_mip.json
 
 # 2D Segmentation
 fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Cellpose Segmentation" --args-parallel Parameters/args_cellpose_segmentation.json --meta-parallel Parameters/meta_cellpose.json

--- a/examples/03_cardio_multiplexing/run_example.sh
+++ b/examples/03_cardio_multiplexing/run_example.sh
@@ -52,7 +52,7 @@ sed "s|__INPUT_PATH__|$INPUT_PATH|g" Parameters/RAW_args_cellvoyager_to_ome_zarr
 # Convert to OME-Zarr
 fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Convert Cellvoyager Multiplexing to OME-Zarr" --args-non-parallel Parameters/args_cellvoyager_to_ome_zarr_init.json --meta-non-parallel Parameters/example_meta.json
 # Maximum intensity projection
-fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Maximum Intensity Projection HCS Plate" --args-non-parallel Parameters/args_mip.json
+fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Project Image (HCS Plate)" --args-non-parallel Parameters/args_mip.json
 
 # Registration
 fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Calculate Registration (image-based)" --args-non-parallel Parameters/calculate_registration_init.json --args-parallel Parameters/calculate_registration.json

--- a/examples/03_cardio_multiplexing/run_example_reversed_cycles.sh
+++ b/examples/03_cardio_multiplexing/run_example_reversed_cycles.sh
@@ -52,7 +52,7 @@ sed "s|__INPUT_PATH__|$INPUT_PATH|g" Parameters/RAW_args_cellvoyager_to_ome_zarr
 # Convert to OME-Zarr
 fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Convert Cellvoyager Multiplexing to OME-Zarr" --args-non-parallel Parameters/args_cellvoyager_to_ome_zarr_reversed_init.json --meta-non-parallel Parameters/example_meta.json
 # Maximum intensity projection
-fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Maximum Intensity Projection HCS Plate" --args-non-parallel Parameters/args_mip.json
+fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Project Image (HCS Plate)" --args-non-parallel Parameters/args_mip.json
 
 # Registration
 fractal --batch workflow add-task "$PROJECT_ID" "$WF_ID" --task-name "Calculate Registration (image-based)" --args-non-parallel Parameters/calculate_registration_init.json --args-parallel Parameters/calculate_registration.json

--- a/examples/06_search_first_custom_cellpose/Parameters/create_zarr_structure_subset.json
+++ b/examples/06_search_first_custom_cellpose/Parameters/create_zarr_structure_subset.json
@@ -31,5 +31,5 @@
     ],
     "coarsening_xy": 2,
     "num_levels": 5,
-    "image_glob_patterns": ["*F001L*", "*Z01*"]
+    "include_glob_patterns": ["*F001L*", "*Z01*"]
 }

--- a/examples/08_scMultipleX_task/Parameters/create_zarr_structure_subset.json
+++ b/examples/08_scMultipleX_task/Parameters/create_zarr_structure_subset.json
@@ -31,6 +31,6 @@
     ],
     "coarsening_xy": 2,
     "num_levels": 5,
-    "image_glob_patterns": ["*F007L*"],
+    "include_glob_patterns": ["*F007L*"],
     "overwrite": true
 }

--- a/examples/user_specific_examples/01_CardiacDifferentiation_23wells/Parameters/create_zarr_structure_subset.json
+++ b/examples/user_specific_examples/01_CardiacDifferentiation_23wells/Parameters/create_zarr_structure_subset.json
@@ -25,7 +25,7 @@
     "coarsening_xy": 2,
     "num_levels": 5,
     "image_extension": "png",
-    "image_glob_patterns": [
+    "include_glob_patterns": [
       "*F001*"
     ],
     "overwrite": true

--- a/examples/user_specific_examples/01_CardiacDifferentiation_23wells/README.md
+++ b/examples/user_specific_examples/01_CardiacDifferentiation_23wells/README.md
@@ -8,7 +8,7 @@ This only needs to be done once (unless the server is restarted again). Follow t
 This needs to be done in each example folder you're running
 4. Switch to this example folder and save the user credentials here by running the `prepare_user.sh` script (TO BE UPDATED, user credentials either need to be provided on each fractal client command or present in the `.fractal.env` in the folder you're running the client from)
 5. Get the example data: `pip install zenodo_get`, then run `. ./fetch_test_data_from_zenodo.sh`
-6. Change whether it's run on a subset of the data or the whole dataset (the `"image_glob_patterns": ["*F001*"]` parameter in create_zarr_structure.json limits it to the first field of view for each well, thus running way faster)
+6. Change whether it's run on a subset of the data or the whole dataset (the `"include_glob_patterns": ["*F001*"]` parameter in create_zarr_structure.json limits it to the first field of view for each well, thus running way faster)
 7. One can then either go through the project creation, dataset creation, workflow creation & submission one by one. Or run it all at once by running: `. ./run_example.sh`
 
 

--- a/examples/user_specific_examples/08_HCA_plate_384well/Parameters/create_zarr_structure.json
+++ b/examples/user_specific_examples/08_HCA_plate_384well/Parameters/create_zarr_structure.json
@@ -31,5 +31,5 @@
     ],
     "coarsening_xy": 2,
     "num_levels": 9,
-    "image_glob_patterns": ["*F016L*"]
+    "include_glob_patterns": ["*F016L*"]
 }


### PR DESCRIPTION
@tcompa I'm adding an additional set of tables to the 2 example datasets: output_ROI_tables, so that we have examples of masking ROI tables in our public test data.

Additionally, everything is now run with fractal-tasks-core 1.2.1.

I'll wait with merging this until you're back, in case this leads to issue in the containerized weekly tests.